### PR TITLE
fix: path to artifact in build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: "_build/html"
+          path: "book/_build/html"
 
       # Deploy the book's HTML to GitHub Pages
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
```
tar: _build/html: Cannot open: No such file or directory
```
https://github.com/developmentseed/scaling_science/actions/runs/8557849551/job/23451088779

Seems the recipe we were following didn't account for the output of the build to be inside the book.
@lillythomas how did you trigger an Action to build originally, manual command line?