### PR TITLE
Remove duplicate entry in toc

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -2,7 +2,6 @@ format: jb-book
 root: docs/index
 chapters:
   - file: docs/Open_data_code.ipynb
-  - file: docs/Open_formats_tools.ipynb
   - file: docs/Use_of_notebooks.ipynb
   - file: docs/Containerization.ipynb
   - file: docs/Open_formats_tools.ipynb


### PR DESCRIPTION
Fixes build failure introduced in #4a2b91a by removing duplicate entry in `_toc.yml`.