### PR TITLE
feat: enable interactive plots with requirejs loading

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -70,6 +70,8 @@ sphinx:
 #    latex_show_urls: 'footnote'
     latex_elements.papersize: a4paper
     latex_elements.pointsize: 12pt
+    html_js_files:
+    - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js
 
 #google_analytics:
 #  mytrackingcode: UA-205698170-1


### PR DESCRIPTION
Make interactive plots work. This only works for some types of plots, in this case plotly based plots. For more info see https://jupyterbook.org/en/stable/interactive/interactive.html

The only way to know this works is to try it locally, I use `python -m http.server` to test.